### PR TITLE
Remove duplicate log messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ typings/
 # next.js build output
 .next
 
+
+/typeset/*-baked.*html
+/typeset/output*.*html

--- a/typeset/converter.js
+++ b/typeset/converter.js
@@ -194,7 +194,12 @@ const injectMathJax = async (log, inputPath, cssPath, outputPath, mathJaxPath) =
       }
       let msg = document.getElementById('MathJax_Message')
       if (msg && msg.innerText !== '') {
-        console.info(`Progress: "${document.getElementById('MathJax_Message').innerText}"`)
+        const newMessage = `Progress: "${document.getElementById('MathJax_Message').innerText}"`
+        // Do not emit to the log every second if the message did not change
+        if (newMessage !== window.__TYPESET_CONFIG.previousMessage) {
+          console.info(newMessage)
+          window.__TYPESET_CONFIG.previousMessage = newMessage
+        }
       }
       return {
         isDone: window.__TYPESET_CONFIG.isDone,

--- a/typeset/tests/typeset.test.js
+++ b/typeset/tests/typeset.test.js
@@ -45,7 +45,7 @@ test('Success if everything is ok.', async (done) => {
   expect(res).toBe(converter.STATUS_CODE.OK)
   expect(isOutputFile).toBeTruthy()
   done()
-}, 15000)
+}, 30000)
 
 test('Test output file for containing MathJax converted elements and do not contain MathML elements.', async (done) => {
   const browser = await puppeteer.launch({
@@ -75,4 +75,4 @@ test('Test output file for containing MathJax converted elements and do not cont
   expect(res.mathJaxClasses).toBeGreaterThan(0)
   expect(res.mathMLElements).toEqual(0)
   done()
-}, 15000)
+}, 30000)


### PR DESCRIPTION
Currently, the output looks like the following (`96%` is printed every second)

```
16:33:56.691Z  INFO node-typeset: browser-console Progress: "Typesetting math: 95%"
16:34:56.691Z  INFO node-typeset: browser-console Progress: "Typesetting math: 96%"
16:35:04.299Z  INFO node-typeset: browser-console Progress: "Typesetting math: 96%"
16:36:56.691Z  INFO node-typeset: browser-console Progress: "Typesetting math: 96%"
```

This Pull Request changes it so that output looks more like the following:

```
16:33:56.691Z  INFO node-typeset: browser-console Progress: "Typesetting math: 95%"
16:37:56.691Z  INFO node-typeset: browser-console Progress: "Typesetting math: 96%"
16:43:04.299Z  INFO node-typeset: browser-console Progress: "Typesetting math: 97%"
16:55:56.691Z  INFO node-typeset: browser-console Progress: "Typesetting math: 98%"
```
